### PR TITLE
Dev shell nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # tamagokill
 Tamagochi, mais version Mirror universe ; Le but n'est pas de le tenir en vie, mais de le tuer. Projet open-source avec la communauté sur Twitch. Pour fêter les 4k followers.
 
+## Préparation de l'environnement de développement
+
+### Dev shell nix
+
+Si vous utilisez [nix](https://nixos.org/download/) (Linux ou MacOS), vous pouvez utiliser le shell de développement pour avoir un environnement de développement cohérent.
+
+Dans votre terminal, à la racine du projet, exécutez:
+```bash
+nix-shell
+```
+
+Si vous avez [activé les flakes](https://nixos.wiki/wiki/Flakes), vous pouvez aussi exécuter:
+```bash
+nix develop
+```
+
+Une fois dans le devshell, vous aurez accès à la bonne version de `node` et `rust` et toutes les dépendances nécessaires (par exemple `cargo-watch` pour le hot reload de l'api, et `gitflow` pour gérer vos branches).
+
 ## Workflow Gitflow
 https://www.atlassian.com/fr/git/tutorials/comparing-workflows/gitflow-workflow
 http://danielkummer.github.io/git-flow-cheatsheet/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,101 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717334035,
+        "narHash": "sha256-e2jatwgwcYFvhc+1hhkX5eBuPfcx7/VCqmkXkZ0a7rQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cba27b4bc216c4e95eedf98ea6514e400ffb26e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717294752,
+        "narHash": "sha256-QhlS52cEQyx+iVcgrEoCnEEpWUA6uLdmeLRxk935inI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b46857a406d207a1de74e792ef3b83e800c30e08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,48 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05-small";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "github:edolstra/flake-compat";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs =
+  { self
+  , nixpkgs
+  , flake-utils
+  , rust-overlay
+  , ...
+  }:
+  flake-utils.lib.eachDefaultSystem (system:
+  let
+    pkgs = import nixpkgs { inherit system; overlays = [ (import rust-overlay) ]; };
+
+    rust178 = pkgs.rust-bin.stable."1.78.0".default.override {
+      extensions = [
+        "rust-src"
+        "rust-analyzer"
+        "clippy"
+      ];
+    };
+
+    devBuildInputs = with pkgs; [
+      rust178
+      nodejs_18
+      cargo-watch
+      git
+      gitflow
+      lazygit
+    ];
+  in
+  {
+    devShells = {
+      default = pkgs.mkShell {
+        buildInputs = devBuildInputs;
+      };
+    };
+  });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020-2021 Eelco Dolstra and the flake-compat contributors
+# SPDX-License-Identifier: MIT
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Fix #4

Adds a nix flake defining a development shell.
To use it on a `nix` enabled computer, simply run `nix-shell` (or `nix develop` if you enabled flakes) and you will have a sane development environment.

This is a draft PR, I'd like people to try it
Let's discuss the implementation !