### PR TITLE
feat: check pull requests and commits using conventional commits

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,17 +1,20 @@
-name: ✅ Tamagokill check
+name: 🧪 Run tests
 on:
   pull_request:
     types: [opened, synchronize]
 
 jobs:
-  check-web:
+  web:
+    name: 💻 Web
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🏭 Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ./web/package.json
 
       - name: 📥 Install Web
         working-directory: ./web
@@ -25,15 +28,16 @@ jobs:
         working-directory: ./web
         run: npm run test
 
-      - name: 👷‍♂️ Build Web
+      - name: 👷‍♂️ Check Web
         working-directory: ./web
-        run: npm run build
+        run: npm run check
 
-  check-api:
+  api:
+    name: 🌍 API
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 👷‍♂️ Build API
         working-directory: ./api

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,0 +1,15 @@
+name: ✍️ Verify commit message
+on:
+  push:
+
+jobs:
+  verify-commit-message:
+    name: 🤝 Check conventional commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v4
+      - name: ⛏️ Extract commit message
+        run: echo "${{ github.event.head_commit.message }}" > last-commit-message
+      - name: 🤝 Check conventional commit
+        run: npx git-conventional-commits commit-msg-hook last-commit-message

--- a/.github/workflows/check-pull-requests.yml
+++ b/.github/workflows/check-pull-requests.yml
@@ -1,0 +1,16 @@
+name: 📝 Verify pull request
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+jobs:
+  conventionnal-commit:
+    name: 🔎 PR title and description
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v4
+      - name: ⛏️  Extract pull request title
+        run: echo "${{ github.event.pull_request.title }}" > pull-request-title
+      - name: 🤝 Check conventional commit
+        run: npx git-conventional-commits commit-msg-hook pull-request-title


### PR DESCRIPTION
I added two new more workflows, the purpose is to have better consistency over the commit history and pull requests.

- The `./git-conventional-commits.yaml` configuration file is enforced on the latest commit of the pull request.
- Pull requests must respect a basic name and description regex based on conventional commit specification.
- Improved job and steps names for other workflows.

![image](https://github.com/DevGirl-Team/tamagokill/assets/2821066/d5070cc8-d64e-4467-bb28-60762678651b)
